### PR TITLE
Merge `dev` into `main`: CIAO CI fixes, dependency cleanup, and docs updates

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -50,7 +50,7 @@ jobs:
           channels: https://cxc.cfa.harvard.edu/conda/ciao,conda-forge
           channel-priority: strict
           environment-file: environment-ciao.yml
-          activate-environment: test
+          activate-environment: ciao
 
       - name: Verify CIAO
         shell: bash -l {0}

--- a/README.md
+++ b/README.md
@@ -23,24 +23,25 @@ If you use this code in your research, please cite:
 
 **Requirements:** [Conda](https://docs.conda.io/en/latest/) (Miniconda or Anaconda) and Python 3.12.
 
-1. Clone or download this repository and go to the project root (the directory containing `pyproject.toml` and `environment.yml`).
+1. Clone or download this repository and go to the project root (the directory containing `pyproject.toml`).
 
-2. Create and activate the conda environment from `environment.yml`:
+2. Choose one installation path:
+
+   **Option A (recommended for full functionality, with CIAO):**
+
+   ```bash
+   conda env create -f environment-ciao.yml
+   conda activate ciao
+   pip install -e .
+   superchandra --help
+   ```
+
+   **Option B (core Python workflow, no CIAO in env):**
 
    ```bash
    conda env create -f environment.yml
    conda activate superchandra
-   ```
-
-3. Install the package in editable mode (dependencies are installed from `pyproject.toml`):
-
-   ```bash
    pip install -e .
-   ```
-
-4. Verify the CLI is available:
-
-   ```bash
    superchandra --help
    ```
 

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -6,13 +6,13 @@ This document records how `pyproject.toml` dependencies align with the installab
 
 | Dependency         | Version (pyproject) | Used by |
 |--------------------|---------------------|---------|
-| numpy              | >=1.22              | superchandra.py, utils/math.py, utils/spectrum.py |
-| astropy            | >=5.3               | superchandra.py (votable, coordinates, table, time, fits, wcs), utils/coord.py, tests (conftest, test_utils) |
-| requests           | >=2.28              | superchandra.py (get_obstable), utils/extinction.py (get_MW_Av) |
-| xmltodict          | >=0.12              | superchandra.py (VO table parse), utils/extinction.py (IRSA DUST) |
-| photutils          | >=1.0               | superchandra.py (SkyCircularAperture, SkyCircularAnnulus, aperture_photometry) |
-| python-dateutil    | >=2.8                | superchandra.py (dateparse for --before, --after) |
-| pytest             | >=7.0 (optional [test]) | All tests |
+| numpy              | >=2.4               | superchandra.py, utils/math.py, utils/spectrum.py |
+| astropy            | >=7.2               | superchandra.py (votable, coordinates, table, time, fits, wcs), utils/coord.py, tests (conftest, test_utils) |
+| requests           | >=2.33              | superchandra.py (get_obstable), utils/extinction.py (get_MW_Av) |
+| xmltodict          | >=1.0               | superchandra.py (VO table parse), utils/extinction.py (IRSA DUST) |
+| photutils          | >=2.3               | superchandra.py (SkyCircularAperture, SkyCircularAnnulus, aperture_photometry) |
+| python-dateutil    | >=2.9               | superchandra.py (dateparse for --before, --after) |
+| pytest             | >=9.0 (optional [test]) | All tests |
 
 Stdlib-only imports (not in pyproject): `os`, `sys`, `shutil`, `glob`, `tempfile`, `warnings`, `argparse`, `subprocess`, `tempfile`.
 
@@ -29,4 +29,4 @@ Stdlib-only imports (not in pyproject): `os`, `sys`, `shutil`, `glob`, `tempfile
 
 ## Version bounds (current)
 
-Lower bounds are conservative and compatible with current photutils and astropy. No upper bounds are set in pyproject; when installing into a CIAO conda env, pin numpy in that env as documented in the README.
+Minimum versions in `pyproject.toml` are set to the currently validated dependency stack used by the package install/build/test workflow. No upper bounds are set in pyproject; when installing into a CIAO conda env, pin numpy in that env as documented in the README.

--- a/environment-ciao.yml
+++ b/environment-ciao.yml
@@ -1,7 +1,7 @@
 # Conda environment for CI: CIAO (CXC channel first) + Python 3.12.
 # Used by .github/workflows/build-and-test.yml job "Test with CIAO (latest)".
 # See: https://cxc.cfa.harvard.edu/ciao/threads/ciao_install_conda/
-name: test
+name: ciao
 channels:
   - https://cxc.cfa.harvard.edu/conda/ciao
   - conda-forge

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,17 +13,17 @@ authors = [
     { name = "C. D. Kilpatrick" }
 ]
 dependencies = [
-    "numpy>=1.22",
-    "astropy>=5.3",
-    "requests>=2.28",
-    "xmltodict>=0.12",
-    "photutils>=1.0",
-    "python-dateutil>=2.8",
+    "numpy>=2.4",
+    "astropy>=7.2",
+    "requests>=2.33",
+    "xmltodict>=1.0",
+    "photutils>=2.3",
+    "python-dateutil>=2.9",
 ]
 
 [project.optional-dependencies]
 test = [
-    "pytest>=7.0",
+    "pytest>=9.0",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-numpy==1.22.0
-astropy==5.3.3
-requests==2.32.0
-xmltodict==0.12.0


### PR DESCRIPTION
## Summary
This PR merges `dev` into `main` and includes CI reliability fixes for CIAO testing, dependency/source-of-truth cleanup, and README improvements for installation and workflow visibility.

## What Changed

### CI / Workflow
- Updated GitHub Actions CIAO job to use `Miniforge3` (replacing deprecated `Mambaforge` installer path).
- Added `environment-ciao.yml` and switched CIAO setup to an environment-file workflow.
- Set CIAO environment name to `ciao` and propagated this in CI and docs.
- Improved CIAO installation path in CI to avoid solver/conflict issues.

### Dependencies
- Removed obsolete `requirements.txt` from the repo.
- Consolidated dependency source of truth in `pyproject.toml`.
- Updated dependency docs in `docs/DEPENDENCIES.md` to match current declared/validated dependency set.

### Documentation
- Fixed README build badge URL so workflow status resolves correctly.
- Updated installation instructions to include both:
  - recommended CIAO-enabled install (`environment-ciao.yml`)
  - core non-CIAO install (`environment.yml`)
- Updated README examples to use `conda activate ciao` for CIAO environment workflow.

### Repo Hygiene
- Removed tracked `.venv312` files from git index (while keeping venv ignore rules in place).

## Validation Performed
- Fresh conda environment install with Python 3.12.
- `pip install -e ".[test]"` completed successfully.
- Package build completed successfully (`python -m build`).
- Test run succeeded for non-network, non-CIAO suite:
  - `pytest -m "not ciao and not network" tests/`
  - Result: all selected tests passed.

## Notes
- CIAO integration tests/workflow remain optional in CI due to upstream channel/solver variability.
- Main non-CIAO test workflow remains the required quality gate.

## Checklist
- [x] CI/workflow configuration updated
- [x] Docs updated to reflect current install paths
- [x] Obsolete dependency file removed
- [x] Install/build/tests validated locally
- [ ] Final GitHub Actions run on this PR is green